### PR TITLE
ShellCheck-Action: Use latest master branch

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -18,7 +18,7 @@ workflow "ShellCheck Linting" {
 }
 
 action "ShellCheck-Lint-Action" {
-  uses = "zbeekman/ShellCheck-Lint-Action@v1.0.1"
+  uses = "zbeekman/ShellCheck-Lint-Action@master"
   env = {
     ALWAYS_LINT_ALL_FILES = "true" # current default
   }


### PR DESCRIPTION
Always use latest shellcheck action