### PR TITLE
Update entrypoint to add workspace as safe directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,8 @@ findInCwdOrParent() {
 configureGit() {
   # This should be the default but it's important that it's set correctly
   git config --global core.quotePath true
+  # Prevents unsafe repo error on pull request
+  git config --global --add safe.directory "$GITHUB_WORKSPACE"
 }
 
 getEventByPath() {


### PR DESCRIPTION
# Pull request summary
- Prevents "fatal: unsafe repository ('/github/workspace' is owned by someone else" - https://github.com/actions/checkout/issues/760)" error caused by PRs. 
- Implements git configuration to set the workspace as a safe directory. 

## Additional information
- Solution source: https://github.com/actions/checkout/issues/766
## Pull request checklist

<!-- If you do not fill out the checklist below your pull request may be closed without comment -->

- [X] Have you followed the guidelines in our [Contributing] document?
- [X] Have you checked to ensure there aren't other open [Pull Requests] for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your changes?
- [X] Have you successfully tested your changes locally?

[Contributing]: ../blob/master/CONTRIBUTING.md
[Pull Requests]: ../pulls
