### PR TITLE
Allow validation of code in a subdirectory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -126,7 +126,7 @@ getChangedFiles() {
       else
         echo "File \`$line\` was moved or deleted."
       fi
-    done < <(git diff --name-only "${HEAD_COMMIT}..${BASE_COMMIT}")
+    done < <(git diff --name-only --relative "${HEAD_COMMIT}..${BASE_COMMIT}" -- .)
   elif $have_last && $have_commits ; then
     echo "Missing starting commit, new repo?"
     # We know that core.quotePath is true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,6 +145,11 @@ getChangedFiles() {
 echo "eclint version: $(eclint --version)"
 configureGit
 
+if [ -n "${REPOSITORY_PATH+set}" ]; then
+  echo "Changing directory to $REPOSITORY_PATH"
+  cd "$REPOSITORY_PATH"
+fi
+
 echo "Looking for .editorconfig file in current directory or parents..."
 findInCwdOrParent .editorconfig
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,6 +28,11 @@ findInCwdOrParent() {
 configureGit() {
   # This should be the default but it's important that it's set correctly
   git config --global core.quotePath true
+  
+  if [[ "${ADD_SAFE_DIRECTORY:-false}" = [Tt]rue ]]; then
+    # This prevents errors due to different file ownership from outside the container
+    git config --global --add safe.directory $PWD
+  fi
 }
 
 getEventByPath() {


### PR DESCRIPTION
# Pull request summary

I wanted to set up the EditorConfig-Action in my repository but found a couple of blocking issues:

- The `.editorconfig` and code to check is in a subfolder within the repository
- The sparse checkout from the `actions/checkout` plugin ends up owned by a different user and so needs to be marked as safe

Both of these changes are enabled using properties passed to the action.

You can see the result (from my fork) being used at [Eclipse sensiNact](https://github.com/eclipse/org.eclipse.sensinact.gateway/blob/future/prototype/.github/workflows/format.yml)

## Additional information

## Pull request checklist

<!-- If you do not fill out the checklist below your pull request may be closed without comment -->

- [x] Have you followed the guidelines in our [Contributing] document?
- [x] Have you checked to ensure there aren't other open [Pull Requests] for the same change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes?
- [x] Have you successfully tested your changes locally?

[Contributing]: ../blob/master/CONTRIBUTING.md
[Pull Requests]: ../pulls
